### PR TITLE
Renamed an old  'entityView' to 'containerView'

### DIFF
--- a/proposals/android-extensions-entity-caching.md
+++ b/proposals/android-extensions-entity-caching.md
@@ -89,7 +89,7 @@ Though we lose the View caching feature. The solution is to add an `LayoutContai
 
 ```kotlin
 interface LayoutContainer {
-    val entityView: View?
+    val containerView: View?
 }
 ```
 


### PR DESCRIPTION
There was a small inconsistency in the code. All 'entityView' fields were renamed to 'containerView' recently, except the one in the LayoutContainer snippet.