### PR TITLE
correct kotlinlang slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please don't create new issues unless really necessary, let's try to keep discus
 
 ## How to propose
 
-If you only have a vague feature idea, please share it in the [#language-proposals](https://kotlinlang.slack.com/messages/language-proposals/) channel in our public Slack (get invite [here](http://kotlinslackin.herokuapp.com/)), or in the [Forum's Language design category](https://discuss.kotlinlang.org/c/language-design).
+If you only have a vague feature idea, please share it in the [#language-proposals](https://kotlinlang.slack.com/messages/language-proposals/) channel in our public Slack (get invite [here](http://slack.kotlinlang.org/)), or in the [Forum's Language design category](https://discuss.kotlinlang.org/c/language-design).
 
 If a discussion in these media has lead to a detailed proposal, feel free to submit a pull request here. We appreciate your work, but can not guarantee that all proposals will be considered soon after submission.
 


### PR DESCRIPTION
The link for getting an invite for kotlinlang Slack doesn't work: this PR should fix that.