### PR TITLE
Fix typo

### DIFF
--- a/proposals/unsigned-types.md
+++ b/proposals/unsigned-types.md
@@ -93,7 +93,7 @@ To iterate through a range of unsigned values there will be range and progressio
 ## Experimental status 
 
 The unsigned types are to be released in Kotlin 1.3 as an [experimental feature](experimental.md).
-This means we do not give compatibility guaranties for the API and language features related to unsigned types.
+This means we do not give compatibility guarantees for the API and language features related to unsigned types.
 
 Their usage without an opt-in will produce a compiler warning about their experimentality.
 


### PR DESCRIPTION
Guaranty is kind of a deprecated word. Guarantee better reflects the meaning.