### PR TITLE
[SuccessOrFailure] Fixed return type of findUserByName in the sealed class example

### DIFF
--- a/proposals/stdlib/success-or-failure.md
+++ b/proposals/stdlib/success-or-failure.md
@@ -373,7 +373,7 @@ sealed class FindUserResult {
     // other cases that need different business-specific handling code
 }
 
-fun findUserByName(name: String): UserResult
+fun findUserByName(name: String): FindUserResult
 ```
 
 > This is one of the reasons that `SuccessOrFailure` was not named `Result`. That is, to prevent its abuse


### PR DESCRIPTION
Looks like the return type of `findUserByName` is wrong in the sealed class example. Should be `FindUserResult` instead of `UserResult`.