### PR TITLE
Context receivers: fix functional types sample

### DIFF
--- a/proposals/context-receivers.md
+++ b/proposals/context-receivers.md
@@ -265,17 +265,20 @@ signature of the functional type replicates the textual order in which every arg
 
 * Such assignments are valid:
   ```kotlin
-  class Context {
-      fun Receiver.method(param: Param) {}
-  }
-  
-  fun function(context: Context, receiver: Receiver, p: Param) {}
-  
   fun main() {
-      var g: context(Context) Receiver.(Param) -> Unit
-      g = ::function      // OK
-      g = Context::method // OK 
+    var g: context(Context) Receiver.(Param) -> Unit
+    g = ::foo         // OK
+    g = ::bar         // OK
+    g = Receiver::baz // OK
   }
+  
+  fun foo(context: Context, receiver: Receiver, p: Param) {}
+
+  context(Context)
+  fun bar(receiver: Receiver, p: Param) {}
+
+  context(Context)
+  fun Receiver.baz(p: Param) {}
   ```
 
 ### Referencing specific receiver


### PR DESCRIPTION
The current sample for contextual functional types seems incorrect since we do not support and do not propose the support of callable references for member extensions. I believe the new one shows the same and compiles.