### PR TITLE
Fix typo in fragment with converted code example

### DIFF
--- a/notes/web-workers.md
+++ b/notes/web-workers.md
@@ -255,7 +255,7 @@ is transformed into
 addEventListener("message", ($message) => {
   const { data: { $kind, $captured } } = $message
   if ($kind == "START") {
-    if ($captured.foo == $data.$captured.bar) {
+    if ($captured.foo == $captured.bar) {
       postMessage({
         $kind: "RETURN",
         $result: "Equal",


### PR DESCRIPTION
It probably meant referring to `$captured.bar`, since there is no `$data` in scope