### PR TITLE
Mark Markdown files as `linguist-detectable`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
This makes them show up in the language bar following the precedent of similar repos like [`swift-evolution`](https://github.com/apple/swift-evolution):

<img width="287" alt="image" src="https://user-images.githubusercontent.com/30873659/200888390-1af04345-d1ed-4ca8-866b-1e9a10e6ff69.png">