### PR TITLE
Context-sensitive resolution

### DIFF
--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -296,12 +296,8 @@ The second change relates to any function call, which now must handle delayed ex
 
 1. Resolve all non-lambda arguments, where some of those may become delayed.
 2. During the _applicability_ step, do not introduce information about delayed arguments inside each of the constraint systems.
-  - **Open question**: should we filter out those candidates for which the resolution of the delayed argument with the corresponding parameter type fails?
-  - If the answer to the open question above is affirmative, resolution of the delayed arguments is effectively done in this stage.
 3. The choice of the most specific overload remains the same.
-4. During _completion_ we store information about delayed arguments.
-  - If the answer to the open question above is negative, completion involves resolution using the expected type obtain from the chosen overload.
-  - If the answer to the open question above is affirmative, resolution of delayed arguments has already been performed.
+4. During _completion_ we perform resolution of delayed arguments using the expected type obtain from the chosen overload; in addition to any other tasks in this phase.
 
 ## Design decisions
 
@@ -358,6 +354,8 @@ The problem is that at the expression `value == UNKNOWN`, the known type of `val
 
 - It is unclear in general how to treat intersection types, since other cases may not be as simple as dropping a type argument.
 - If in the future Kotlin gets a feature similar to GADTs, we may piggy back on the knowledge that `T` is equal to `Problem`, and face no problem in computing the single definite expected type.
+
+**Additional filtering of candidates**: should we filter out those candidates for which the resolution of the delayed argument with the corresponding parameter expected type fails? At this point we have decided to go with a "no". This answer has the benefit that if we ever move to "yes", the change is backward compatible, as opposed to the other direction.
 
 ### Risks
 

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -279,7 +279,7 @@ Furthermore, only two kinds of members are available:
 2. No-argument callables, which must:
    - Be either properties or enumeration entries (including properties synthetized from interoperating with other languages, like Java),
    - Have no context receivers nor context parameters.
-   - Have no extension receiver, except for extension functions defined over the companion object of `T`.
+   - Have no extension receiver, except for extension properties defined over the companion object of `T`.
 
 ### Changes to [overload resolution](https://kotlinlang.org/spec/overload-resolution.html#overload-resolution)
 

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -4,7 +4,7 @@
 * **Author**: Alejandro Serrano Mena
 * **Status**: In discussion
 * **Prototype**: Implemented in [this branch](https://github.com/JetBrains/kotlin/compare/rr/serras/improved-resolution-expected-type)
-* **Discussion**: ??
+* **Discussion**: [KEEP-379](https://github.com/Kotlin/KEEP/issues/379)
 * **Related issues**: [KT-9493](https://youtrack.jetbrains.com/issue/KT-9493/Allow-short-enum-names-in-when-expressions), [KT-44729](https://youtrack.jetbrains.com/issue/KT-44729/Context-sensitive-resolution), [KT-16768](https://youtrack.jetbrains.com/issue/KT-16768/Context-sensitive-resolution-prototype-Resolve-unqualified-enum-constants-based-on-expected-type), [KT-58939](https://youtrack.jetbrains.com/issue/KT-58939/K2-Context-sensitive-resolution-of-Enum-leads-to-Unresolved-Reference-when-Enum-has-the-same-name-as-one-of-its-Entries)
 
 ## Abstract

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -16,13 +16,13 @@ We propose an improvement of the name resolution rules of Kotlin based on the ex
 * [Abstract](#abstract)
 * [Table of contents](#table-of-contents)
 * [Motivating example](#motivating-example)
-    * [The issue with overloading](#the-issue-with-overloading)
-    * [Importing the entire static scope](#importing-the-entire-static-scope)
+  * [The issue with overloading](#the-issue-with-overloading)
+  * [Importing the entire scopes](#importing-the-entire-scopes)
 * [Technical details](#technical-details)
-    * [Additional candidate resolution scope](#additional-candidate-resolution-scope)
-    * [Additional type resolution scope](#additional-type-resolution-scope)
+  * [Additional candidate resolution scope](#additional-candidate-resolution-scope)
+  * [Additional type resolution scope](#additional-type-resolution-scope)
 * [Design decisions](#design-decisions)
-    * [Risks](#risks)
+  * [Risks](#risks)
 * [Implementation note](#implementation-note)
 
 ## Motivating example
@@ -74,9 +74,9 @@ Improving the resolution of arguments based on the function call would amount to
 
 As a consequence, operators in Kotlin that are desugared to function calls which in turn get resolved, like `in` or `thing[x]`, are also outside of the scope of this KEEP. Note that [value equalities](https://kotlinlang.org/spec/expressions.html#value-equality-expressions) (`==`, `!=`) are not part of that group, since they are always resolved to `kotlin.Any.equals`.
 
-### Importing the entire static scope
+### Importing the entire scopes
 
-The current proposal imports the _entire_ static scope, which includes classes, properties, and functions. Whereas the first two are needed to cover common cases like enumeration entries, and comparison with objects, the usefulness of methods seems debatable. However, it allows some interesting constructions where we compare against a value coming from a factory:
+The current proposal imports the _entire_ static and companion object scopes, which include classes, properties, and functions. Whereas the first two are needed to cover common cases like enumeration entries, and comparison with objects, the usefulness of methods seems debatable. However, it allows some interesting constructions where we compare against a value coming from a factory:
 
 ```kotlin
 class Color(...) {
@@ -145,7 +145,7 @@ We introduce the additional scope during type solution in the following cases:
 
 ## Design decisions
 
-**Priority level**: the current proposal puts the additional scope to be searched when the expected type is known at the same level as `*`-imports. This means that this feature is _not_ 100% backward-compatible, as we have the risk of ambiguity between a declaration imported in such a way, and one available in the static scope of the expected type.
+**Priority level**: the current proposal puts the additional scope to be searched when the expected type is known at the same level as `*`-imports. This means that this feature is _not_ 100% backward-compatible, as we have the risk of ambiguity between a declaration imported in such a way, and one available in the static or companion object scope of the expected type.
 
 The most conservative option is for the new scope to have the lowest priority. In practical terms, that means that even built-ins and automatically imported declarations have higher priority, which seems like an odd choice too. As mentioned above, the mental model of these scopes working as `*`-imports seems like a useful tool for understanding the feature, so making them have the same priority level feels like a natural next step.
 

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -74,6 +74,12 @@ Improving the resolution of arguments based on the function call would amount to
 
 As a consequence, operators in Kotlin that are desugared to function calls which in turn get resolved, like `in` or `thing[x]`, are also outside of the scope of this KEEP. Note that [value equalities](https://kotlinlang.org/spec/expressions.html#value-equality-expressions) (`==`, `!=`) are not part of that group, since they are always resolved to `kotlin.Any.equals`.
 
+Expected type information is propagate to _none_ of the arguments, and that includes trailing lambda arguments. For example, the following fails to compile:
+
+```kotlin
+fun problemByNumber(n: Int): Problem = n.let { UNKNOWN }
+```
+
 ### Importing the entire scopes
 
 The current proposal imports the _entire_ static and companion object scopes, which include classes, properties, and functions. Whereas the first two are needed to cover common cases like enumeration entries, and comparison with objects, the usefulness of methods seems debatable. However, it allows some interesting constructions where we compare against a value coming from a factory:
@@ -132,6 +138,12 @@ If a type `T` is propagated to a block, then the type is propagated to every ret
 
 * _Explicit `return`_: `return e`,
 * _Implicit `return`_: the last statement.
+
+If a functional type `(...) -> R` is propagated to a lambda, then the return type `R` is propagated to the body of the lambda (alongside the parameter types being propagated to the formal parameters, if available).
+
+```kotlin
+val unknown: () -> Problem = { UNKNOWN }
+```
 
 For other statements and expressions, we have the following rules. Here "known type of `x`" includes any additional typing information derived from smart casting.
 

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -1,0 +1,147 @@
+# Improve resolution using expected type
+
+* **Type**: Design proposal
+* **Author**: Alejandro Serrano Mena
+* **Status**: In discussion
+* **Prototype**: Implemented in [this branch](https://github.com/JetBrains/kotlin/compare/rr/serras/improved-resolution-expected-type)
+* **Discussion**: ??
+* **Related issues**: [KT-9493](https://youtrack.jetbrains.com/issue/KT-9493/Allow-short-enum-names-in-when-expressions), [KT-44729](https://youtrack.jetbrains.com/issue/KT-44729/Context-sensitive-resolution), [KT-16768](https://youtrack.jetbrains.com/issue/KT-16768/Context-sensitive-resolution-prototype-Resolve-unqualified-enum-constants-based-on-expected-type)
+
+## Abstract
+
+We propose an improvement of the name resolution rules of Kotlin based on the expected type of the expression. The goal is to decrease the amount of qualifications when the type of the expression is known.
+
+## Table of contents
+
+* [Abstract](#abstract)
+* [Table of contents](#table-of-contents)
+* [Motivating example](#motivating-example)
+    * [The issue with overloading](#the-issue-with-overloading)
+* [Technical details](#technical-details)
+    * [Additional candidate resolution scope](#additional-candidate-resolution-scope)
+    * [Additional type resolution scope](#additional-type-resolution-scope)
+* [Potential additions](#potential-additions)
+    * [Equality](#equality)
+    * [Nested inheritors](#nested-inheritors)
+* [Implementation note](#implementation-note)
+
+## Motivating example
+
+The current rules of the language sometimes require Kotliners to qualify some members, where it feels that such qualification could be inferred from the types already spelled out in the code. One [infamous example](https://youtrack.jetbrains.com/issue/KT-9493/Allow-short-enum-names-in-when-expressions) is enumeration entries, which always live inside their defining class. In the example below, we need to write `Problem.`, even though `Problem` is already explicit in the type of the `problem` argument or the return type of `problematic`.
+
+```kotlin
+enum class Problem {
+    CONNECTION, AUTHENTICATION, DATABASE, UNKNOWN
+}
+
+fun message(problem: Problem): String = when (problem) {
+    Problem.CONNECTION -> "connection"
+    Problem.AUTHENTICATION -> "authentication"
+    Problem.DATABASE -> "database"
+    Problem.UNKNOWN -> "unknown"
+}
+
+fun problematic(x: String): Problem = when (x) {
+    "connection" -> Problem.CONNECTION
+    "authentication" -> Problem.AUTHENTICATION
+    "database" -> Problem.DATABASE
+    else -> Problem.UNKNOWN
+}
+```
+
+This KEEP addresses many of these problems by considering explicit expected types when doing name resolution. We try to propagate the information from argument and return types, declarations, and similar constructs. As a result, the following constructs are usually improved:
+
+* conditions on `when` expressions with subject,
+* type checks and casts (`is`, `as`),
+* `return`, both implicit and explicit,
+* we propose an alternative to improve equality (`==`, `!=`).
+
+### The issue with overloading
+
+We leave out of this KEEP the improvement of resolution for arguments of functions. Taking the example above, you still need to qualify the argument to `message`.
+
+```kotlin
+val s = message(Problem.CONNECTION)
+```
+
+What sets function calls apart from the constructs mentioned before is overloading. In Kotlin, there's a certain sequence in which function calls are resolved and type checked, as spelled out in the [specification](https://kotlinlang.org/spec/overload-resolution.html#overload-resolution).
+
+1. Infer the types of non-lambda arguments.
+2. Choose an overload for the function based on the gathered type.
+3. Check the types of lambda arguments (including inferring some remaining type arguments if `@BuilderInference` is present).
+
+Improving the resolution of arguments based on the function call would amount to reversing the order of (1) and (2), at least partially. There are potential techniques to solve this problem, but another KEEP seems more appropriate.
+
+As a consequence, operators in Kotlin that are desugared to function calls, like `in` or `thing[x]`, are also outside of the scope of this KEEP.
+
+## Technical details
+
+We introduce an additional scope, present both in type and candidate resolution, which always depends on a type `T` (we say we **propagate `T`**). This scope contains the static and companion object callables of the aforementioned type `T`, as defined by the [specification](https://kotlinlang.org/spec/overload-resolution.html#call-with-an-explicit-type-receiver).
+
+This scope is added at the lowest priority level. This ensures that we do not change the current behavior, we only extend the amount of programs that are accepted.
+
+This scope is **not** propagated to children of the node in question. For example, when resolving `val x: T = f(x, y)`, the additional scope is present when resolving `f`, but not when resolving `x` and `y`. After all, `x` and `y` no longer have an expected type `T`.
+
+### Additional candidate resolution scope
+
+We propagate `T` to an expression `e` whenever the specification states _"the type of `e` must be a subtype of `T`"_. 
+
+For declarations, a type `T` is propagated to the body, which may be an expression or a block. Note that we only propagate types given _explicitly_ by the developer.
+
+* _Default parameters of functions_: `x: T = e`;
+* _Initializers of properties with explicit type_: `val x: T = e`;
+* _Explicit return types of functions_: `fun f(...): T = e` or `fun f(...): T { ... }`,
+* _Getters of properties with explicit type_: `val x: T get() = e` or `val x: T get() { ... }`.
+
+If a type `T` is propagated to a block, then the type is propagated to every return point of the block.
+
+* _Explicit `return`_: `return e`,
+* _Implicit `return`_: the last statement.
+
+For other statements and expressions, we have the following rules. Here "known type of `x`" includes any additional typing information derived from smart casting.
+
+* _Assignments_: in `x = e`, the known type of `x` is propagated to `e`,
+* _Branching_: if type `T` is propagated to a conditional (`if`) or `when` expressions, the type `T` is propagated to each of their branches,
+* _`when` expression with subject_: in `when (x) { e -> ... }`, then known type of `x` is propagated to `e`, when `e` is not of the form `is T` or `in e`,
+* _Elvis operator_: if type `T` is propagated to `e1 ?: e2`, then we propagate `T?` to `e1` and `T` to `e2`.
+* _Type cast_: in `e as T` and `e as? T`, the type `T` is propagated to `e`,
+    * This rule follows from the similarity to doing `val x: T = e`.
+
+### Additional type resolution scope
+
+We introduce the additional scope during type solution in the following cases:
+
+* _Type check_: in `e is T`, `e !is T`, the known type of `e` is propagated to `T`.
+* _`when` expression with subject_: in `when (x) { is T -> ... }`, then known type of `x` is propagated to `T`.
+
+## Potential additions
+
+### Equality
+
+It is possible (and implemented in the prototype) to add the additional propagation rule:
+
+* _Equality_: in `a == b` and `a != b`, then known type of `a` is propagated to `b`.
+
+This helps in common cases like `p == Problem.CONNECTION`.
+
+However, there are two potential problems with this approach, which require further discussion.
+
+1. It is not symmetric: it might be surprising that `p == CONNECTION` is accepted, but `CONNECTION == p` is rejected.
+2. The [specification](https://kotlinlang.org/spec/expressions.html#value-equality-expressions) mandates `a == b` to be equivalent to `(A as? Any)?.equals(B as Any?) ?: (B === null)` in the general case. So there is no actual type expected from `b` merely from participating in equality.
+
+### Nested inheritors
+
+The rules above handle enumeration, and it's also useful when defining a hierarchy of classes nested on the parent.
+
+```kotlin
+sealed interface Either<out E, out A> {
+  data class Left<E>(error: E): Either<E, Nothing>
+  data class Right<A>(value: A): Either<Nothing, E>
+}
+```
+
+One way in which we can improve resolution even more is by considering the subclasses of the known type of an expression. Making every potential subclass available would be quite surprising, but sealed hierarchies form an interesting subset (and the information is directly accessible to the compiler). However, this means getting away from a more "syntactical" choice (nested elements of the type), which may be surprising.
+
+## Implementation note
+
+In the current K2 compiler, these rules amount to considering those places in which `WithExpectedType` is passed as the `ResolutionMode`, plus adding special rules for `as`, `is`, and `==`. Since `when` with subject is desugared as either `x == e` or `x is T`, we need no additional rules to cover them.

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -270,6 +270,7 @@ For other statements and expressions, we have the following rules. Here "known t
 
 * _Assignments_: in `x = e`, the expected type of `x` is propagated to `e`;
 * _Type check_: in `e is T`, `e !is T`, the known type of `e` is propagated to `T`;
+* _Type cast_: in `e as T`, `e as? T`, the known type of `e` is propagated to `T`;
 * _Branching_: if type `T` is expected for an with several branches, the type `T` is propagated to each of them,
     * _Conditionals_, either `if` or `when`,
     * _`try` expressions_, where the type `T` is propagated to the `try` block and each of the `catch` handlers;
@@ -387,11 +388,6 @@ One very important difference with Swift is that we take a restrictive route, in
 The current choice is obviously not symmetric: it might be surprising that `p == CONNECTION` is accepted, but `CONNECTION == p` is rejected. A preliminary assessment shows that the pattern `CONSTANT == variable` is not as prevalent in the Kotlin community as in other programming languages.
 
 On the other hand, the proposed flow of information is consistent with the ability to refactor `when (x) { A -> ...}` into `when { x == A -> ...}`, without any further qualification required. We think that this uniformity is important for developers.
-
-**On type cast**: a previous iteration included the additional rule "in `e as T` and `e as? T`, the known type of `e` is propagated to `T`", but this has been dropped. There are two reasons for this change:
-
-1. On a conceptual level, it is not immediately obvious what happens if `e as T` as a whole also has an expected type: should `T` be resolved using the known type of `e` or that expected type? It's possible to create an example where depending on the answer the resolution differs, and this could be quite surprising to users.
-2. On a technical level, the compiler _sometimes_ uses the type `T` to guide generic instantiation of `e`. This conflicts with the rule above.
 
 **Interaction with smart casting**: the main place in which the notion of "single definite expected type" may bring some problems is smart castings, as they are the main source of intersection types.
 

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -278,7 +278,8 @@ Furthermore, only two kinds of members are available:
 1. Classifiers which are nested in and inherit from type `T`, if `T` is a `sealed` class.
 2. No-argument callables, which must:
    - Be either properties or enumeration entries (including properties synthetized from interoperating with other languages, like Java),
-   - Have no extension receiver nor context parameters, except for imported extension functions defined over the companion object of `T`.
+   - Have no context receivers nor context parameters.
+   - Have no extension receiver, except for extension functions defined over the companion object of `T`.
 
 ### Changes to [overload resolution](https://kotlinlang.org/spec/overload-resolution.html#overload-resolution)
 
@@ -289,12 +290,9 @@ In order to accomodate improved resolution for function arguments, the algorithm
 3. _Choice of most specific overload_: if more than one applicable overload remains after the previous step, try to decide which is the "most specific" by applying [some rules](https://kotlinlang.org/spec/overload-resolution.html#choosing-the-most-specific-candidate-from-the-overload-candidate-set). After this step, only one overload should remain, otherwise an _ambiguity error_ is issued.
 4. _Completion_: use the information from the chosen overload to resolve lambda arguments, callable references, and fix type variables.
 
-The first change relates to _no-argument expressions_, that is, those made only from a [`simpleIdentifier`](https://kotlinlang.org/spec/syntax-and-grammar.html#grammar-rule-simpleIdentifier).
+The first change relates to _no-argument expressions_, that is, those made only from a [`simpleIdentifier`](https://kotlinlang.org/spec/syntax-and-grammar.html#grammar-rule-simpleIdentifier). In that case only the _applicability_ step of the previous list apply. If during that phase no potential overloads are found, and the expression appears as argument to a function, then do not issue an error, but rather mark the expression as **delayed**.
 
-1. The expression has no argument, so step (1) does not apply.
-2. If during the _applicability_ phase no potential overloads are found, and the expression appears as argument to a function, then do not issue an error, but rather mark the expression as **delayed**.
-
-The second change relates to any function call, which now must handle delayed expressions as arguments.
+The second change relates to any function call, which now must handle delayed expressions as arguments. The resolution algorithm is modified as follows.
 
 1. Resolve all non-lambda arguments, where some of those may become delayed.
 2. During the _applicability_ step, do not introduce information about delayed arguments inside each of the constraint systems.

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -297,9 +297,11 @@ The second change relates to any function call, which now must handle delayed ex
 1. Resolve all non-lambda arguments, where some of those may become delayed.
 2. During the _applicability_ step, do not introduce information about delayed arguments inside each of the constraint systems.
   - **Open question**: should we filter out those candidates for which the resolution of the delayed argument with the corresponding parameter type fails?
+  - If the answer to the open question above is affirmative, resolution of the delayed arguments is effectively done in this stage.
 3. The choice of the most specific overload remains the same.
-4. During _completion_, delayed arguments are resolved again using the expected type obtained from the overload chosen in step (3).
-  - If the answer to open question above is affirmative, such resolution would be done as part of the applicability step.
+4. During _completion_ we store information about delayed arguments.
+  - If the answer to the open question above is negative, completion involves resolution using the expected type obtain from the chosen overload.
+  - If the answer to the open question above is affirmative, resolution of delayed arguments has already been performed.
 
 ## Design decisions
 

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -129,8 +129,6 @@ For other statements and expressions, we have the following rules. Here "known t
     * _`try` expressions_, where the type `T` is propagated to the `try` block and each of the `catch` handlers,
 * _Elvis operator_: if type `T` is propagated to `e1 ?: e2`, then we propagate `T?` to `e1` and `T` to `e2`.
 * _Not-null assertion_: if type `T` is propagated to `e!!`, then we propagate `T?` to `e`,
-* _Type cast_: in `e as T` and `e as? T`, the type `T` is propagated to `e`,
-    * This rule follows from the similarity to doing `val x: T = e`.
 * _Equality_: in `a == b` and `a != b`, the known type of `a` is propagated to `b`.
     * This helps in common cases like `p == Problem.CONNECTION`.
     * Note that in this case the expected type should only be propagated for the purposes of name resolution. The [specification](https://kotlinlang.org/spec/expressions.html#value-equality-expressions) mandates `a == b` to be equivalent to `(A as? Any)?.equals(B as Any?) ?: (B === null)` in the general case, so from a typing perspective there should be no constraint on the type of `b`.
@@ -142,6 +140,7 @@ All other operators and compound assignments (such as `x += e`) do not propagate
 We introduce the additional scope during type solution in the following cases:
 
 * _Type check_: in `e is T`, `e !is T`, the known type of `e` is propagated to `T`.
+* _Type cast_: in `e as T` and `e as? T`, the known type of `e` is propagated to `T`.
 * _`when` expression with subject_: in `when (x) { is T -> ... }`, then known type of `x` is propagated to `T`.
 
 ## Design decisions

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -291,15 +291,15 @@ There are some scenarios in which the expected type propagation may lead to comp
 * Built-in and classifier types: `sdet(T) = T`.
   * Note that type arguments do not influence the scope.
 * Type parameters:
-  * If there is a single supertype, `<T : A>`, `sdet(T) = sdet(A)`,
+  * If there is a single supertype, `<T : A>`, (recursively) compute `sdet(T) = sdet(A)`,
   * Otherwise, `sdet(T)` is undefined.
-* Nullable types: `sdet(T?) = sdet(T)`.
+* Nullable types: (recursively) compute `sdet(T?) = sdet(T)`.
 * Types with variance:
   * Covariance, `sdet(out T) = sdet(T)`,
   * For contravariant arguments, `sdet(in T)` is undefined.
 * Captured types: `sdet(T)` is undefined.
 * Flexible types, `sdet(A .. B)`
-  * Compute `sdet(A)` and `sdet(B)`, and take it if they coincide; otherwise undefined.
+  * (Recursively) compute `sdet(A)` and `sdet(B)`, and take it if they coincide; otherwise undefined.
   * This rule covers `A .. A?` as special case.
 * Intersection types, `sdet(A & B)`,
   * Definitely not-null, `sdet(A & Any) = sdet(A)`,

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -172,7 +172,7 @@ sealed interface Either<out E, out A> {
 
 One way in which we can improve resolution even more is by considering the subclasses of the known type of an expression. Making every potential subclass available would be quite surprising, but sealed hierarchies form an interesting subset (and the information is directly accessible to the compiler).
 
-At this point, we have decided against it for practical reasons. If the subclasses are defined inside the parent class (like in `Either` above), this proposal already helps because the subclasses are in the static scope of the parent. If they are inside the parent, then we are not making the particular piece of code any smaller, only avoiding one import. Since imports are usually disregarded by the developers anyway, it seems that adding all sealed subclasses to the scope brings no additional benefit.
+At this point, we have decided against it for practical reasons. If the subclasses are defined inside the parent class (like in `Either` above), this proposal already helps because the subclasses are in the static scope of the parent. If they are defined outside of the parent, then we are not making the particular piece of code any smaller, only avoiding one import. Since imports are usually disregarded by the developers anyway, it seems that adding all sealed subclasses to the scope brings no additional benefit.
 
 ### Risks
 

--- a/proposals/improved-resolution-expected-type.md
+++ b/proposals/improved-resolution-expected-type.md
@@ -132,9 +132,9 @@ With this design, it is always clear which is the sole type from which we obtain
 
 ## Technical details
 
-We introduce an additional scope, present both in type and candidate resolution, which always depends on a type `T` (we say we **propagate `T`**). This scope contains the static and companion object callables of the aforementioned type `T`, as defined by the [specification](https://kotlinlang.org/spec/overload-resolution.html#call-with-an-explicit-type-receiver).
+We introduce an additional scope, present both in type and candidate resolution, which always depends on a type `T` (we say we **propagate `T`**). This scope contains the static and companion object callables of the aforementioned type `T`, as defined by the [specification](https://kotlinlang.org/spec/overload-resolution.html#call-with-an-explicit-type-receiver). In platforms that allow defining static callables directly on types, like the JVM, those are included too.
 
-This scope has the lowest priority and _should keep_ that lowest priority even after further extensions to the language. The mental model is that the expected type is only use for resolution purposes after any other possibility has failed.
+This scope has the lowest priority (even lower than that of default and star imports) and _should keep_ that lowest priority even after further extensions to the language. The mental model is that the expected type is only use for resolution purposes after any other possibility has failed.
 
 This scope is **not** propagated to children of the node in question. For example, when resolving `val x: T = f(x, y)`, the additional scope is present when resolving `f`, but not when resolving `x` and `y`. After all, `x` and `y` no longer have an expected type `T`.
 
@@ -168,7 +168,7 @@ val unknown: () -> Problem = {
 For other statements and expressions, we have the following rules. Here "known type of `x`" includes any additional typing information derived from smart casting.
 
 * _Assignments_: in `x = e`, the known type of `x` is propagated to `e`,
-* _`when` expression with subject_: in `when (x) { t -> ... }`, then known type of `x` is propagated to `t`, when `c` is an expression (that is, not of the form `is S`, `in l`, or their negations),
+* _`when` expression with subject_: in `when (x) { t -> ... }`, then known type of `x` is propagated to `t`, when `t` is an expression (that is, not of the form `is S`, `in l`, or their negations),
     * For [guards](https://github.com/Kotlin/KEEP/blob/guards/proposals/guards.md) `when (x) { t if c -> ... }`, the type is propagated to `t`, but not to the guard `c`,
 * _Branching_: if type `T` is propagated to an expression with several branches, the type `T` is propagated to each of them,
     * _Conditionals_, either `if` or `when`,


### PR DESCRIPTION
Only comment here about the text itself. The discussion about the feature is done in #379.

We propose an improvement of the name resolution rules of Kotlin based on the expected type of the expression. The goal is to decrease the amount of qualifications when the type of the expression is known.