### PR TITLE
Resolution of links to extensions in KDoc

### DIFF
--- a/proposals/kdoc/links-to-extensions.md
+++ b/proposals/kdoc/links-to-extensions.md
@@ -4,7 +4,7 @@
 * **Author**: Oleg Yukhnevich
 * **Status**: Submitted
 * **Target issue**: [dokka/3555](https://github.com/Kotlin/dokka/issues/3555)
-* **Discussion**: TBD
+* **Discussion**: [KEEP-385](https://github.com/Kotlin/KEEP/issues/385)
 
 ## Summary
 


### PR DESCRIPTION
Only comment here about the text itself. The discussion about the feature is done in https://github.com/Kotlin/KEEP/issues/385

The goal of the proposal is to try to describe consistent rules on how KDoc links to extensions should be resolved.