### PR TITLE
Nested (non-capturing) type aliases

### DIFF
--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -161,7 +161,7 @@ class Example<T> {
     // = capture(Inner<Int>, capture(Example<S>, { T }))
     // = capture(Inner<Int>, { S })
     // = capture(Int) + { S } = { S } ⊆ { S } => OK
-    typelias Boo<S> = Example<S>.Inner
+    typealias Boo<S> = Example<S>.Inner
 }
 ```
 

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -3,8 +3,8 @@
 * **Type**: Design proposal
 * **Author**: Alejandro Serrano
 * **Contributors**: Ivan Kochurkin
-* **Discussion**: 
-* **Status**: 
+* **Discussion**: [KEEP-406](https://github.com/Kotlin/KEEP/issues/406)
+* **Status**: In discussion
 * **Related YouTrack issue**: [KT-45285](https://youtrack.jetbrains.com/issue/KT-45285/Support-nested-and-local-type-aliases)
 
 ## Abstract

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -113,7 +113,7 @@ class Service {
 > [!TIP]
 > As a rule of thumb, a nested type alias is correct if it could be used as the supertype or a parameter type within a nested class living within the same classifier.
 
-We formally define the set of captured type parameters of a type `T` with enclosing parameters `P`, `captured(T, P)`, as follows.
+We formally define the set of captured type parameters of a type `T` with enclosing parameters `P`, `capture(T, P)`, as follows.
 
 - If `T` is a type parameter, `capture(T, P) = { T }`;
 - If `T` is a nested type access `A.B`, `capture(T, P) = capture(B, capture(A, P))`;

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -2,7 +2,7 @@
 
 * **Type**: Design proposal
 * **Author**: Alejandro Serrano
-* **Contributors**: 
+* **Contributors**: Ivan Kochurkin
 * **Discussion**: 
 * **Status**: 
 * **Related YouTrack issue**: [KT-45285](https://youtrack.jetbrains.com/issue/KT-45285/Support-nested-and-local-type-aliases)

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -1,0 +1,118 @@
+# Nested (and inner) type aliases
+
+* **Type**: Design proposal
+* **Author**: Alejandro Serrano
+* **Contributors**: 
+* **Discussion**: 
+* **Status**: 
+* **Related YouTrack issue**: [KT-45285](https://youtrack.jetbrains.com/issue/KT-45285/Support-nested-and-local-type-aliases)
+
+## Abstract
+
+Right now type aliases can only be used at the top level. The goal of this document is to propose a design to allow them within other classifiers.
+
+## Table of contents
+
+* [Abstract](#abstract)
+* [Table of contents](#table-of-contents)
+* [Motivation](#motivation)
+* [Proposed solution](#proposed-solution)
+* [Design questions](#design-questions)
+
+## Motivation
+
+Type aliases can simplify understanding and maintaining code. For example, we can give a domain-related name to a more "standard" type,
+
+```kotlin
+typealias Context = Map<TypeVariable, Type>
+```
+
+As opposed to value classes, type aliases are "transparent" to the compiler, so any functionality available through `Map` is also available through `Context`.
+
+Currently, type aliases may only be declared at the top level. This hinders their potential, since type aliases may be very useful in a private part of the implementation; so forcing to introduce the type alias at the top level pollutes the corresponding package. This document aims to rectify this situation, by providing a set of rules for type aliasing within other declarations.
+
+```kotlin
+class Dijkstra {
+    typelias VisitedNodes = Set<Node>
+
+    private fun step(visited: VisitedNodes, ...) = ...
+}
+```
+
+It is a **non-goal** of this KEEP to provide abstraction capabilities over type aliases, like [abstract type members](https://docs.scala-lang.org/tour/abstract-type-members.html) in Scala or [associated type synonyms](https://wiki.haskell.org/GHC/Type_families) in Haskell. Roughly speaking, this would entail declaring a type alias without its left-hand side in an interface or abstract class, and "overriding" it in an implementing class.
+
+```kotlin
+interface Collection {
+    typealias Element
+}
+
+interface List<T>: Collection {
+    typealias Element = T
+}
+
+interface IntArray: Collection {
+    typealias Element = Int
+}
+```
+
+## Proposed solution
+
+We need to care about two separate axes for nested type aliases.
+
+- **Visibility**: we should guarantee that type aliases do not expose types to a broader scope than originally intended.
+- **Inner**: classifiers defined inside another classifier may be marked as [inner](https://kotlinlang.org/spec/declarations.html#nested-and-inner-classifiers), which requires an instance of the outer type to be in the context. Once again, nested type aliases should not break those guarantees.
+
+We extend the syntax of type aliases as follows. A type alias declaration marked with the `inner` keyword is said to be _inner_, otherwise we refer to it as _nested_.
+
+```
+[modifiers] ['inner'] 'typealias' simpleIdentifier [{typeParameters}] '=' type
+```
+
+**Rule 1 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present in its left-hand side.
+
+```kotlin
+class Outer {
+    internal class Inner { }
+
+    // wrong: public typealias mentions internal class
+    typealias One = List<Inner>
+
+    // ok: private typealias mentions only public and internal classes
+    private typealias Two = Map<String, Inner>
+}
+```
+
+**Rule 2 (inner)**: type aliases referring to inner classes must be marked as `inner`.
+
+- Inner type aliases may also refer only to non-inner classes.
+
+```kotlin
+class Big {
+  class Nested { }
+  inner class Inner { }
+
+  typealias A = Nested  // ok
+  typealias B = Inner   // wrong
+  inner typealias C = Nested  // ok
+  inner typealias D = Inner   // ok
+}
+```
+
+## Design questions
+
+**Question 1 (inner on other values)**: should we allow inner type aliases to depend not only on the outer instance but also on other properties?
+
+```kotlin
+class Foo(val big: Big) {  // 'Big' as above
+  inner typealias X = big.Inner
+}
+```
+
+One important question here is what is the semantics of such a definition:
+
+- Is the left-hand side chosen during initialization?
+- Should we ensure that the type alias is somehow "stable"? If so, what are the rules for such stable references to types?
+
+**Question 2 (expect / actual)**: should we allow nested `expect` (and correspondingly, `actual`) type aliases?
+
+- This is very close to abstracting over types, which is a non-goal of this KEEP.

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -4,7 +4,7 @@
 * **Author**: Alejandro Serrano
 * **Contributors**: Ivan Kochurkin
 * **Discussion**: [KEEP-406](https://github.com/Kotlin/KEEP/issues/406)
-* **Status**: In discussion
+* **Status**: Experimental in Kotlin 2.2
 * **Related YouTrack issue**: [KT-45285](https://youtrack.jetbrains.com/issue/KT-45285/Support-nested-and-local-type-aliases)
 
 ## Abstract

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -17,6 +17,7 @@ Right now type aliases can only be used at the top level. The goal of this docum
 * [Table of contents](#table-of-contents)
 * [Motivation](#motivation)
 * [Proposed solution](#proposed-solution)
+    * [Reflection](#reflection)
 * [Design questions](#design-questions)
 
 ## Motivation
@@ -110,6 +111,12 @@ class Big {
   inner typealias D = Inner   // ok
 }
 ```
+
+### Reflection
+
+The main reflection capabilities in [`kotlin.reflect`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/) work with expanded types. As a result, this KEEP does not affect this part of the library.
+
+The current version of [`kotlinx-metadata`](https://kotlinlang.org/api/kotlinx-metadata-jvm/) already supports [type aliases within any declaration](https://kotlinlang.org/api/kotlinx-metadata-jvm/kotlin-metadata-jvm/kotlin.metadata/-km-declaration-container/type-aliases.html). So in principle the public API is already prepared for this change.
 
 ## Design questions
 

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -116,7 +116,7 @@ class Service {
 We formally define the set of captured type parameters of a type `T` with enclosing parameters `P`, `capture(T, P)`, as follows.
 
 - If `T` is a type parameter, `capture(T, P) = { T }`;
-- If `T` is a nested type access `A.B`, `capture(T, P) = capture(B, capture(A, P))`;
+- If `T` is a nested type access `A.B`, `capture(T, P) = C + capture(B, C)` where `C = capture(A, P))`;
 - If `T` is an inner type `I<A, ..., Z>`, `capture(T, P) = capture(A, P) + ... + capture(Z, P) + P`;
 - If `T` is of the form `C<A, ..., Z>`, with `C` not inner, or `(A, ..., Y) -> Z`, `capture(T, P) = capture(A, P) + ... + capture(Z, P)`;
 - If `T` is a nullable type `R?`, `capture(T, P) = capture(R, P)`;
@@ -158,9 +158,9 @@ class Example<T> {
     typealias Moo = Inner<Int>
 
     // capture(Example<S>.Inner<Int>, { T })
-    // = capture(Inner<Int>, capture(Example<S>, { T }))
-    // = capture(Inner<Int>, { S })
-    // = capture(Int) + { S } = { S } ⊆ { S } => OK
+    // = capture(Example<S>, { T }) + capture(Inner<Int>, capture(Example<S>, { T }))
+    // = { S } + capture(Inner<Int>, { S })
+    // = { S } + capture(Int, { S }) + { S } = { S } ⊆ { S } => OK
     typealias Boo<S> = Example<S>.Inner
 }
 ```
@@ -193,6 +193,7 @@ val d = A().C.D()  // ⚠️ cannot use `C.D()` to refer to a function
 import A.*  // imports `I`
 import C.*  // imports `D`
 
+val i = A().I()
 val d = A().D()
 ```
 

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -61,7 +61,7 @@ interface IntArray: Collection {
 We need to care about two separate axes for nested type aliases.
 
 - **Visibility**: we should guarantee that type aliases do not expose types to a broader scope than originally intended.
-- **Inner**: classifiers defined inside another classifier may be marked as [inner](https://kotlinlang.org/spec/declarations.html#nested-and-inner-classifiers), which means they capture the type parameters of the enclosing type. Once again, nested type aliases should not break those guarantees.
+- **Inner**: classifiers defined inside another classifier may be marked as [inner](https://kotlinlang.org/spec/declarations.html#nested-and-inner-classifiers), which means they capture the type parameters of the enclosing type. Type aliases should not break any type system guarantees.
 
 We extend the syntax of type aliases as follows. A type alias declaration marked with the `inner` keyword is said to be _inner_, otherwise we refer to it as _nested_.
 
@@ -71,19 +71,19 @@ We extend the syntax of type aliases as follows. A type alias declaration marked
 
 **Rule 1 (scope)**: nested type aliases live in the same scope as nested classifiers and inner type aliases live in the same scope as inner classifiers.
 
-- In particular, type aliases cannot be overriden in child classes. Creating a new type alias with the same name as in a parent class merely _hides_ the parent one.
+- In particular, type aliases cannot be overriden in child classes. Creating a new type alias with the same name as in a parent class merely _hides_ that from the parent.
 
 **Rule 2 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present on its right-hand side. Type parameters mentioned in the right-hand side should not be accounted.
 
 ```kotlin
-class Outer {
-    internal class Inner { }
+class Service {
+    internal class Info { }
 
     // wrong: public typealias mentions internal class
-    typealias One = List<Inner>
+    typealias One = List<Info>
 
     // ok: private typealias mentions only public and internal classes
-    private typealias Two = Map<String, Inner>
+    private typealias Two = Map<String, Info>
 }
 ```
 
@@ -103,7 +103,7 @@ class Example<T> {
 }
 ```
 
-We refer to nested and inner typealiases in the same way that we do with nested and inner classifiers.
+We refer to nested and inner typealiases in the same way that we do with other nested and inner classifiers.
 
 ```kotlin
 fun example1(
@@ -116,7 +116,7 @@ fun example1(
 
 **Rule 4 (inner classes)**: type aliases which refer to inner classes within the same classifier and do not prefix it with a path must be marked as `inner`. The reasoning behind it is that inner classes implicitly capture the type parameters of the outer class.
 
-- Note that it is possible to create a nested type alias when a full type is given.
+- Note that it is possible to create a nested (not inner!) type alias when a full type is given.
 
 ```kotlin
 class Example<T> {

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -153,8 +153,8 @@ class Example<T> {
     inner class Inner<A> { }
 
     // capture(Inner<Int>, { T })
-    // = capture(Int) + { T }
-    // = { T } ⊈ { T } => not allowed
+    // = capture(Int, { T }) + { T }
+    // = { T } ⊈ { } => not allowed
     typealias Moo = Inner<Int>
 
     // capture(Example<S>.Inner<Int>, { T })

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -40,7 +40,7 @@ class Dijkstra {
 }
 ```
 
-It is a **non-goal** of this KEEP to provide abstraction capabilities over type aliases, like [abstract type members](https://docs.scala-lang.org/tour/abstract-type-members.html) in Scala or [associated type synonyms](https://wiki.haskell.org/GHC/Type_families) in Haskell. Roughly speaking, this would entail declaring a type alias without its left-hand side in an interface or abstract class, and "overriding" it in an implementing class.
+It is a **non-goal** of this KEEP to provide abstraction capabilities over type aliases, like [abstract type members](https://docs.scala-lang.org/tour/abstract-type-members.html) in Scala or [associated type synonyms](https://wiki.haskell.org/GHC/Type_families) in Haskell. Roughly speaking, this would entail declaring a type alias without its right-hand side in an interface or abstract class, and "overriding" it in an implementing class.
 
 ```kotlin
 interface Collection {
@@ -73,7 +73,7 @@ We extend the syntax of type aliases as follows. A type alias declaration marked
 
 - In particular, type aliases cannot be overriden in child classes. Creating a new type alias with the same name as in a parent class merely _hides_ the parent one.
 
-**Rule 2 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present on its left-hand side.
+**Rule 2 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present on its right-hand side.
 
 ```kotlin
 class Outer {
@@ -130,7 +130,7 @@ class Foo(val big: Big) {  // 'Big' as above
 
 One important question here is what is the semantics of such a definition:
 
-- Is the left-hand side chosen during initialization?
+- Is the type side chosen during initialization?
 - Should we ensure that the type alias is somehow "stable"? If so, what are the rules for such stable references to types?
 
 **Question 2 (expect / actual)**: should we allow nested `expect` (and correspondingly, `actual`) type aliases?

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -34,7 +34,7 @@ Currently, type aliases may only be declared at the top level. This hinders thei
 
 ```kotlin
 class Dijkstra {
-    typelias VisitedNodes = Set<Node>
+    typealias VisitedNodes = Set<Node>
 
     private fun step(visited: VisitedNodes, ...) = ...
 }

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -68,7 +68,7 @@ We extend the syntax of type aliases as follows. A type alias declaration marked
 [modifiers] ['inner'] 'typealias' simpleIdentifier [{typeParameters}] '=' type
 ```
 
-**Rule 1 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present in its left-hand side.
+**Rule 1 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present on its left-hand side.
 
 ```kotlin
 class Outer {
@@ -82,7 +82,16 @@ class Outer {
 }
 ```
 
-**Rule 2 (inner)**: type aliases referring to inner classes must be marked as `inner`.
+**Rule 2 (type parameters)**: nested type aliases may refer to the type parameters of the enclosing classifier. They may also add their own, as usual with type aliases.
+
+```kotlin
+class Example<T> {
+    typealias Bar = List<T>
+    typealias Quux<A> = Map<T, A>
+}
+```
+
+**Rule 3 (inner)**: type aliases referring to inner classes must be marked as `inner`.
 
 - Inner type aliases may also refer only to non-inner classes.
 

--- a/proposals/nested-typealias.md
+++ b/proposals/nested-typealias.md
@@ -68,7 +68,11 @@ We extend the syntax of type aliases as follows. A type alias declaration marked
 [modifiers] ['inner'] 'typealias' simpleIdentifier [{typeParameters}] '=' type
 ```
 
-**Rule 1 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present on its left-hand side.
+**Rule 1 (scope)**: nested type aliases live in the same scope as nested classifiers and inner type aliases live in the same scope as inner classifiers.
+
+- In particular, type aliases cannot be overriden in child classes. Creating a new type alias with the same name as in a parent class merely _hides_ the parent one.
+
+**Rule 2 (visibility)**: the visibility of a type alias must be equal to or weaker than the visibility of every type present on its left-hand side.
 
 ```kotlin
 class Outer {
@@ -82,7 +86,7 @@ class Outer {
 }
 ```
 
-**Rule 2 (type parameters)**: nested type aliases may refer to the type parameters of the enclosing classifier. They may also add their own, as usual with type aliases.
+**Rule 3 (type parameters)**: nested type aliases may refer to the type parameters of the enclosing classifier. They may also add their own, as usual with type aliases.
 
 ```kotlin
 class Example<T> {
@@ -91,7 +95,7 @@ class Example<T> {
 }
 ```
 
-**Rule 3 (inner)**: type aliases referring to inner classes must be marked as `inner`.
+**Rule 4 (inner)**: type aliases referring to inner classes must be marked as `inner`. The same [restrictions to inner classes](https://kotlinlang.org/spec/declarations.html#nested-and-inner-classifiers) apply to inner type aliases.
 
 - Inner type aliases may also refer only to non-inner classes.
 


### PR DESCRIPTION
Only comment here about the text itself. The discussion about the feature is done in #406.

Right now type aliases can only be used at the top level. The goal of this document is to propose a design to allow them within other classifiers, in case they do not capture any type parameters of the enclosing declaration.