### PR TITLE
Fix broken internal link in coroutines.md (coroutine builders section)

### DIFF
--- a/proposals/coroutines.md
+++ b/proposals/coroutines.md
@@ -759,7 +759,7 @@ fun <T> sequence(block: suspend SequenceScope<T>.() -> Unit): Sequence<T> = Sequ
 
 It uses a different primitive from the standard library called 
 [`createCoroutine`](http://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/create-coroutine.html) 
-which is similar to `startCoroutine` (that was explained in [coroutine builders](coroutine-builders) section). 
+which is similar to `startCoroutine` (that was explained in [coroutine builders](#coroutine-builders) section). 
 However it _creates_ a coroutine, but does _not_ start it. 
 Instead, it returns its _initial continuation_ as a reference to `Continuation<Unit>`:
 


### PR DESCRIPTION
In `coroutines.md`, the internal link to the "coroutine builders" section was incorrectly written as `[coroutine builders](coroutine-builders)`,  
which does not work because it lacks the `#` symbol required for internal navigation.

### Fix:
- Changed `[coroutine builders](coroutine-builders)` → `[coroutine builders](#coroutine-builders)`.
- This ensures proper navigation within the same document.

Tested and confirmed that the link now correctly redirects to the intended section.

Let me know if any further modifications are needed. Thanks!