### PR TITLE
Fix incorrect term "Coroutine interceptor" → "Continuation Interceptor"

### DIFF
--- a/proposals/coroutines.md
+++ b/proposals/coroutines.md
@@ -759,7 +759,7 @@ fun <T> sequence(block: suspend SequenceScope<T>.() -> Unit): Sequence<T> = Sequ
 
 It uses a different primitive from the standard library called 
 [`createCoroutine`](http://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/create-coroutine.html) 
-which is similar to `startCoroutine` (that was explained in [coroutine builders](coroutine-builders) section). 
+which is similar to `startCoroutine` (that was explained in [coroutine builders](#coroutine-builders) section). 
 However it _creates_ a coroutine, but does _not_ start it. 
 Instead, it returns its _initial continuation_ as a reference to `Continuation<Unit>`:
 

--- a/proposals/coroutines.md
+++ b/proposals/coroutines.md
@@ -1548,10 +1548,10 @@ It is very convenient to write cooperative single-threaded applications, because
 deal with concurrency and shared mutable state. JS, Python and many other languages do 
 not have threads, but have cooperative multitasking primitives.
 
-[Coroutine interceptor](#coroutine-interceptor) provides a straightforward tool to ensure that
+[Continuation Interceptor](#continuation-interceptor) provides a straightforward tool to ensure that
 all coroutines are confined to a single thread. The example code
 [here](https://github.com/kotlin/kotlin-coroutines-examples/tree/master/examples/context/threadContext.kt) defines `newSingleThreadContext()` function that
-creates a single-threaded execution services and adapts it to the coroutine interceptor
+creates a single-threaded execution services and adapts it to the continuation interceptor
 requirements.
 
 We will use it with `future{}` coroutine builder that was defined in [building futures](#building-futures) section


### PR DESCRIPTION
## Description
This pull request fixes a terminology inaccuracy in the documentation.

**Before:**
"Coroutine interceptor provides a straightforward tool..."

**After:**
"Continuation Interceptor provides a straightforward tool..."

In Kotlin Coroutines, Continuation Interceptor is the correct and official term used to describe a CoroutineContext.Element that intercepts coroutine resumptions. The phrase "coroutine interceptor" is imprecise and does not correspond to any actual type or interface in the Kotlin standard library. This change improves clarity and consistency with Kotlin's coroutine terminology.