### PR TITLE
[KEEP-0451] Fix compiler argument name

### DIFF
--- a/proposals/KEEP-0451-shared-internals.md
+++ b/proposals/KEEP-0451-shared-internals.md
@@ -584,7 +584,7 @@ members are shared.
 ### Deprecations
 
 We expect the Kotlin compiler to phase out all forms of "friend modules" in
-favor of this proposal. This includes, among others, the `-Xfriends-path`
+favor of this proposal. This includes, among others, the `-Xfriend-paths`
 compiler argument.
 
 ### Tooling


### PR DESCRIPTION
The actual argument is `-Xfriend-paths`, not `-Xfriends-path`.

Ref: https://github.com/JetBrains/kotlin/blob/2.1.0/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt#L516